### PR TITLE
Add Unit.UK2

### DIFF
--- a/DarkSkyApi.Test/ApiTests.cs
+++ b/DarkSkyApi.Test/ApiTests.cs
@@ -106,11 +106,27 @@ namespace DarkSkyApi.Test
         /// <summary>
         /// Checks that requests can be made with Unit.UK.
         /// </summary>
+        [Test]
         public async Task UnitUKWorksCorrectly()
         {
             var client = new DarkSkyService(apiKey);
 
             var result = await client.GetWeatherDataAsync(MumbaiLatitude, MumbaiLongitude, Unit.UK);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Currently, Is.Not.Null);
+        }
+
+        /// <summary>
+        /// Checks that requests can be made with Unit.UK2.
+        /// Added to test GitHub issue 18.
+        /// </summary>
+        [Test]
+        public async Task UnitUK2WorksCorrectly()
+        {
+            var client = new DarkSkyService(apiKey);
+
+            var result = await client.GetWeatherDataAsync(MumbaiLatitude, MumbaiLongitude, Unit.UK2);
 
             Assert.That(result, Is.Not.Null);
             Assert.That(result.Currently, Is.Not.Null);

--- a/DarkSkyApi/DarkSkyService.cs
+++ b/DarkSkyApi/DarkSkyService.cs
@@ -505,7 +505,7 @@ namespace DarkSkyApi
         /// </returns>
         private static async Task<Forecast> ParseForecastFromResponse(HttpResponseMessage response)
         {
-            using (var responseStream = await response.Content.ReadAsStreamAsync())
+            using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
             {
                 var serializer = new DataContractJsonSerializer(typeof(Forecast));
                 var result = serializer.ReadObject(responseStream);
@@ -531,13 +531,13 @@ namespace DarkSkyApi
             var compressionHandler = GetCompressionHandler();
             using (var client = new HttpClient(compressionHandler))
             {
-                var response = await client.GetAsync(requestUrl);
+                var response = await client.GetAsync(requestUrl).ConfigureAwait(false);
 
                 ThrowExceptionIfResponseError(response);
 
                 UpdateApiCallsMade(response);
 
-                return await ParseForecastFromResponse(response);
+                return await ParseForecastFromResponse(response).ConfigureAwait(false);
             }
         }
 

--- a/DarkSkyApi/RequestParameters.cs
+++ b/DarkSkyApi/RequestParameters.cs
@@ -78,6 +78,25 @@ namespace DarkSkyApi
         UK,
 
         /// <summary>
+        /// UK units of measurement. The same as SI, except that 
+        /// nearestStormDistance and visibility are in miles and windSpeed 
+        /// is in miles per hour
+        /// <para>
+        /// Summaries containing temperature or snow accumulation units have
+        /// their values in degrees Celsius or centimeters (respectively).
+        /// Nearest storm distance: Miles
+        /// Precipitation intensity: Millimeters per hour
+        /// Precipitation accumulation: Centimeters
+        /// Temperature: Celsius
+        /// Dew Point: Celsius
+        /// Wind Speed: Miles per hour
+        /// Pressure: Hectopascals (equivalent to millibars)
+        /// Visibility: Miles
+        /// </para>
+        /// </summary>
+        UK2,
+
+        /// <summary>
         /// Automatically choose units of measurement based on geographic location.
         /// </summary>
         Auto
@@ -205,6 +224,8 @@ namespace DarkSkyApi
                     return "ca";
                 case Unit.UK:
                     return "uk";
+                case Unit.UK2:
+                    return "uk2";
                 case Unit.Auto:
                     return "auto";
                 default:


### PR DESCRIPTION
- Add enum value.
- Add "uk2" return string to ToValue extension method.
- Add test.
- Add missing test attribute to UnitUKWorksCorrectly test method.

Fix for issue #18 